### PR TITLE
fix: improve mobile responsive layout for Presentations

### DIFF
--- a/src/components/sections/Presentations.tsx
+++ b/src/components/sections/Presentations.tsx
@@ -20,11 +20,11 @@ export function Presentations() {
             <span className="number-marker text-xs mt-0.5">
               {String(index + 1).padStart(2, '0')}
             </span>
-            <div className="flex-1 min-w-0 flex justify-between gap-4">
+            <div className="flex-1 min-w-0 flex flex-col sm:flex-row sm:justify-between gap-1 sm:gap-4">
               <span className="text-sm group-hover:text-[var(--accent)] transition-colors">
                 {item.title}
               </span>
-              <span className="text-[var(--text-muted)] text-sm text-right shrink-0">
+              <span className="text-[var(--text-muted)] text-sm sm:text-right sm:shrink-0">
                 {item.event}
               </span>
             </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -45,35 +45,35 @@ function RootComponent() {
         {/* Header */}
         <header className="fixed top-0 left-0 right-0 z-50">
           <div className="mx-4 mt-4">
-            <nav className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between glass-card">
+            <nav className="max-w-6xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between glass-card overflow-x-auto">
               <Link
                 to="/"
-                className="font-semibold tracking-tight hover:text-[var(--accent)] transition-colors"
+                className="font-semibold tracking-tight hover:text-[var(--accent)] transition-colors shrink-0"
               >
                 yamitzky.dev
               </Link>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 shrink-0">
                 <a
                   href="/#presentation"
-                  className="px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)]"
+                  className="px-2 sm:px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)] whitespace-nowrap"
                 >
                   Presentations
                 </a>
                 <a
                   href="/#oss"
-                  className="px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)]"
+                  className="px-2 sm:px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)] whitespace-nowrap"
                 >
                   Works
                 </a>
                 <Link
                   to="/blog"
-                  className="px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)]"
+                  className="px-2 sm:px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)] whitespace-nowrap"
                 >
                   Blog
                 </Link>
                 <Link
                   to="/resume"
-                  className="px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)]"
+                  className="px-2 sm:px-4 py-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors rounded-lg hover:bg-[var(--bg-elevated)] whitespace-nowrap"
                 >
                   Resume
                 </Link>

--- a/src/routes/resume.tsx
+++ b/src/routes/resume.tsx
@@ -170,7 +170,7 @@ function ResumePage() {
 
       {/* Header */}
       <header className="resume-header mb-12 animate-reveal">
-        <div className="flex items-baseline justify-between mb-2 print:mb-1">
+        <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-0 mb-2 print:mb-1 print:flex-row print:items-baseline print:justify-between">
           <h1 className="text-3xl font-bold print:text-2xl">小笠原 光貴</h1>
           <p className="text-sm text-[var(--text-muted)] print:text-xs">
             2026年1月18日
@@ -267,7 +267,7 @@ function ResumePage() {
               <div key={exp.company} className="company-block">
                 {/* Company Header + Roles */}
                 <div className="mb-6 print:mb-4">
-                  <div className="flex items-baseline justify-between">
+                  <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-0 print:flex-row print:items-baseline print:justify-between">
                     <h3 className="text-xl font-semibold print:text-base print:font-bold">
                       {exp.company}
                     </h3>


### PR DESCRIPTION
Stack title and event vertically on mobile screens to prevent text from breaking character by character in narrow columns.