### PR TITLE
feat: add blog link to resume page

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,10 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ResumeRouteImport } from './routes/resume'
+import { Route as ApiFeedRouteImport } from './routes/api/feed'
 import { Route as BlogRouteImport } from './routes/blog'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as ApiFeedRouteImport } from './routes/api/feed'
+import { Route as ResumeRouteImport } from './routes/resume'
 
 const ResumeRoute = ResumeRouteImport.update({
   id: '/resume',
@@ -112,8 +112,9 @@ export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
+import type { getRouter } from './router.tsx'
+
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,10 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ApiFeedRouteImport } from './routes/api/feed'
+import { Route as ResumeRouteImport } from './routes/resume'
 import { Route as BlogRouteImport } from './routes/blog'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as ResumeRouteImport } from './routes/resume'
+import { Route as ApiFeedRouteImport } from './routes/api/feed'
 
 const ResumeRoute = ResumeRouteImport.update({
   id: '/resume',
@@ -112,9 +112,8 @@ export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { createStart } from '@tanstack/react-start'
 import type { getRouter } from './router.tsx'
-
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true

--- a/src/routes/resume.tsx
+++ b/src/routes/resume.tsx
@@ -224,10 +224,33 @@ function ResumePage() {
             </svg>
             Web
           </a>
+          <a
+            href="https://yamitzky.dev/blog"
+            target="_blank"
+            rel="noreferrer"
+            className="pill"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"
+              />
+            </svg>
+            Blog
+          </a>
         </div>
         {/* Print only: simple contact info */}
         <p className="hidden print:block text-sm text-gray-600">
-          GitHub: github.com/yamitzky | X: @yamitzky | Web: yamitzky.dev
+          GitHub: github.com/yamitzky | X: @yamitzky | Web: yamitzky.dev | Blog:
+          yamitzky.dev/blog
         </p>
       </header>
 

--- a/src/routes/resume.tsx
+++ b/src/routes/resume.tsx
@@ -249,8 +249,9 @@ function ResumePage() {
         </div>
         {/* Print only: simple contact info */}
         <p className="hidden print:block text-sm text-gray-600">
-          GitHub: github.com/yamitzky | X: @yamitzky | Web: yamitzky.dev | Blog:
-          yamitzky.dev/blog
+          GitHub: github.com/yamitzky | X: @yamitzky | Web:{' '}
+          <a href="https://yamitzky.dev">yamitzky.dev</a> | Blog:{' '}
+          <a href="https://yamitzky.dev/blog">yamitzky.dev/blog</a>
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- Resume ページのヘッダーに Blog へのリンクを追加
- 印刷用テキストにも Blog 情報を追加

## Test plan
- [ ] Resume ページで Blog リンクが表示されることを確認
- [ ] リンクをクリックして https://yamitzky.dev/blog に遷移することを確認
- [ ] 印刷プレビューで Blog 情報が表示されることを確認