### PR TITLE
feat: AI Engineering Night の登壇情報を追加

### DIFF
--- a/src/data/presentations.ts
+++ b/src/data/presentations.ts
@@ -2,6 +2,12 @@ import type { Presentation } from '@/types'
 
 export const presentations: Presentation[] = [
   {
+    event: 'AI Engineering Night 〜エージェント構築とデータ整備の実践知〜',
+    title: '後任はAIです。〜情シスをAIにまかせて会社を休んでみた話〜',
+    url: 'https://findy-tools.connpass.com/event/394417/',
+    year: 2026,
+  },
+  {
     event: '情シス・コーポレートITのSaaSアカウント管理　効率化の取り組み',
     title: 'ひとり情シスなCTOがLLMと始めるオペレーション最適化',
     url: 'https://findy.connpass.com/event/358280/',


### PR DESCRIPTION
## Summary
- 「AI Engineering Night 〜エージェント構築とデータ整備の実践知〜」(2026) の登壇情報を追加
- タイトル: 「後任はAIです。〜情シスをAIにまかせて会社を休んでみた話〜」

## Test plan
- [ ] 登壇一覧ページで新しいエントリが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)